### PR TITLE
Re add `check` and `in`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM concourse/buildroot:base
 MAINTAINER https://github.com/starkandwayne/bosh2-errand-resource
 
+ADD check /opt/resource/check
+ADD in /opt/resource/in
 ADD out /opt/resource/out
 
 RUN chmod +x /opt/resource/*

--- a/check/check_command.go
+++ b/check/check_command.go
@@ -1,0 +1,32 @@
+package check
+
+import (
+	"github.com/starkandwayne/bosh2-errand-resource/bosh"
+	"github.com/starkandwayne/bosh2-errand-resource/concourse"
+)
+
+type CheckCommand struct {
+	director bosh.Director
+}
+
+func NewCheckCommand(director bosh.Director) CheckCommand {
+	return CheckCommand{
+		director: director,
+	}
+}
+
+func (c CheckCommand) Run(checkRequest concourse.CheckRequest) ([]concourse.Version, error) {
+	manifest, err := c.director.DownloadManifest()
+	if err != nil {
+		return []concourse.Version{}, err
+	}
+
+	version := concourse.NewVersion(manifest, checkRequest.Source.Target)
+
+	var concourseOutput = []concourse.Version{}
+	if version != checkRequest.Version {
+		concourseOutput = append(concourseOutput, version)
+	}
+
+	return concourseOutput, nil
+}

--- a/check/check_command_test.go
+++ b/check/check_command_test.go
@@ -1,0 +1,91 @@
+package check_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"errors"
+
+	"github.com/starkandwayne/bosh2-errand-resource/bosh/boshfakes"
+	"github.com/starkandwayne/bosh2-errand-resource/check"
+	"github.com/starkandwayne/bosh2-errand-resource/concourse"
+)
+
+var _ = Describe("CheckCommand", func() {
+	var (
+		checkCommand check.CheckCommand
+		director     *boshfakes.FakeDirector
+	)
+
+	BeforeEach(func() {
+		director = new(boshfakes.FakeDirector)
+		checkCommand = check.NewCheckCommand(director)
+	})
+
+	Describe("Run", func() {
+		var checkRequest concourse.CheckRequest
+
+		BeforeEach(func() {
+			manifestContents := []byte{0xFE, 0xED, 0xDE, 0xAD, 0xBE, 0xEF}
+			director.DownloadManifestReturns(manifestContents, nil)
+		})
+
+		Context("When the manifest SHA does not match with the version provided", func() {
+			BeforeEach(func() {
+				checkRequest = concourse.CheckRequest{
+					Source: concourse.Source{
+						Target: "director.example.com",
+					},
+					Version: concourse.Version{},
+				}
+			})
+
+			It("returns the SHA1 of the manifest", func() {
+				checkResponse, err := checkCommand.Run(checkRequest)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(director.DownloadManifestCallCount()).To(Equal(1))
+				Expect(checkResponse).To(Equal([]concourse.Version{
+					{
+						ManifestSha1: "33bf00cb7a45258748f833a47230124fcc8fa3a4",
+						Target:       "director.example.com",
+					},
+				}))
+			})
+		})
+
+		Context("When the manifest SHA matches the version provided to the check", func() {
+			BeforeEach(func() {
+				checkRequest = concourse.CheckRequest{
+					Source: concourse.Source{
+						Target: "director.example.com",
+					},
+					Version: concourse.Version{
+						ManifestSha1: "33bf00cb7a45258748f833a47230124fcc8fa3a4",
+						Target:       "director.example.com",
+					},
+				}
+			})
+
+			It("retuns an empty versions array", func() {
+				checkResponse, err := checkCommand.Run(checkRequest)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(director.DownloadManifestCallCount()).To(Equal(1))
+				Expect(checkResponse).To(Equal([]concourse.Version{}))
+			})
+		})
+
+		Context("When the there is an error downloading the manifest", func() {
+			BeforeEach(func() {
+				director.DownloadManifestReturns([]byte{}, errors.New("No manifest for you"))
+			})
+
+			It("returns the error", func() {
+				_, err := checkCommand.Run(checkRequest)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("No manifest for you"))
+			})
+		})
+	})
+})

--- a/check/check_suite_test.go
+++ b/check/check_suite_test.go
@@ -1,0 +1,13 @@
+package check_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestOut(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Check Suite")
+}

--- a/cmd/check/check_suite_test.go
+++ b/cmd/check/check_suite_test.go
@@ -1,0 +1,15 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+// There are no tests, we just want to make sure it builds
+
+func TestCheck(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Check Suite")
+}

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"io/ioutil"
+
+	"github.com/starkandwayne/bosh2-errand-resource/bosh"
+	"github.com/starkandwayne/bosh2-errand-resource/check"
+	"github.com/starkandwayne/bosh2-errand-resource/concourse"
+)
+
+func main() {
+	stdin, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot read configuration: %s\n", err)
+		os.Exit(1)
+	}
+
+	checkRequest, err := concourse.NewCheckRequest(stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid parameters: %s\n", err)
+		os.Exit(1)
+	}
+
+	cliCoordinator := bosh.NewCLICoordinator(checkRequest.Source, os.Stderr)
+	commandRunner := bosh.NewCommandRunner(cliCoordinator)
+	cliDirector, err := cliCoordinator.Director()
+	if err != nil {
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
+	}
+	director := bosh.NewBoshDirector(checkRequest.Source, commandRunner, cliDirector)
+
+	checkCommand := check.NewCheckCommand(director)
+	checkResponse, err := checkCommand.Run(checkRequest)
+	if err != nil {
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	concourseOutputFormatted, err := json.MarshalIndent(checkResponse, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not generate version: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stdout, "%s", concourseOutputFormatted)
+}

--- a/cmd/in/in_suite_test.go
+++ b/cmd/in/in_suite_test.go
@@ -1,0 +1,15 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+// There are no tests, we just want to make sure it builds
+
+func TestIn(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "In Suite")
+}

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/starkandwayne/bosh2-errand-resource/bosh"
+	"github.com/starkandwayne/bosh2-errand-resource/concourse"
+	"github.com/starkandwayne/bosh2-errand-resource/in"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr,
+			"not enough args - usage: %s <target directory>\n",
+			os.Args[0],
+		)
+		os.Exit(1)
+	}
+
+	stdin, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot read configuration: %s\n", err)
+		os.Exit(1)
+	}
+
+	inRequest, err := concourse.NewInRequest(stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid parameters: %s\n", err)
+		os.Exit(1)
+	}
+
+	targetDir := os.Args[1]
+
+	if inRequest.Source.Target == concourse.MissingTarget {
+		inResponse := in.InResponse{Version: inRequest.Version}
+		printResponse(inResponse)
+		os.Exit(0)
+	}
+
+	cliCoordinator := bosh.NewCLICoordinator(inRequest.Source, os.Stderr)
+	commandRunner := bosh.NewCommandRunner(cliCoordinator)
+	cliDirector, err := cliCoordinator.Director()
+	if err != nil {
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
+	}
+	director := bosh.NewBoshDirector(inRequest.Source, commandRunner, cliDirector)
+
+	inCommand := in.NewInCommand(director)
+	inResponse, err := inCommand.Run(inRequest, targetDir)
+	if err != nil {
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	printResponse(inResponse)
+}
+
+func printResponse(inResponse in.InResponse) {
+	concourseInputFormatted, err := json.MarshalIndent(inResponse, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not generate version: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stdout, "%s", concourseInputFormatted)
+}

--- a/concourse/check_request.go
+++ b/concourse/check_request.go
@@ -1,0 +1,21 @@
+package concourse
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+type CheckRequest struct {
+	Source  Source  `json:"source"`
+	Version Version `json:"version"`
+}
+
+func NewCheckRequest(request []byte) (CheckRequest, error) {
+	var checkRequest CheckRequest
+	if err := json.NewDecoder(bytes.NewReader(request)).Decode(&checkRequest); err != nil {
+		return CheckRequest{}, fmt.Errorf("Invalid parameters: %s\n", err)
+	}
+
+	return checkRequest, nil
+}

--- a/concourse/in_params.go
+++ b/concourse/in_params.go
@@ -1,0 +1,9 @@
+package concourse
+
+type CompiledRelease struct {
+	Name string `json:"name"`
+}
+
+type InParams struct {
+	CompiledReleases []CompiledRelease `json:"compiled_releases,omitempty"`
+}

--- a/concourse/in_params.go
+++ b/concourse/in_params.go
@@ -1,9 +1,4 @@
 package concourse
 
-type CompiledRelease struct {
-	Name string `json:"name"`
-}
-
 type InParams struct {
-	CompiledReleases []CompiledRelease `json:"compiled_releases,omitempty"`
 }

--- a/concourse/in_request.go
+++ b/concourse/in_request.go
@@ -1,0 +1,28 @@
+package concourse
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+const MissingTarget = "MISSING-TARGET-SHORTCIRCUIT.example.com"
+
+type InRequest struct {
+	Source  Source   `json:"source"`
+	Version Version  `json:"version"`
+	Params  InParams `json:"params"`
+}
+
+func NewInRequest(request []byte) (InRequest, error) {
+	var inRequest InRequest
+	if err := json.NewDecoder(bytes.NewReader(request)).Decode(&inRequest); err != nil {
+		return InRequest{}, fmt.Errorf("Invalid parameters: %s\n", err)
+	}
+
+	if inRequest.Source.Target == "" {
+		inRequest.Source.Target = MissingTarget
+	}
+
+	return inRequest, nil
+}

--- a/concourse/in_request_test.go
+++ b/concourse/in_request_test.go
@@ -1,0 +1,22 @@
+package concourse_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/starkandwayne/bosh2-errand-resource/concourse"
+)
+
+var _ = Describe("InRequest", func() {
+	Describe("NewInRequest", func() {
+		Context("when the target is empty", func() {
+			It("It sets a placeholder so newing up the director does not fail validation", func() {
+				request := []byte(`{}`)
+
+				inRequest, err := concourse.NewInRequest(request)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(inRequest.Source.Target).To(Equal(concourse.MissingTarget))
+			})
+		})
+	})
+})

--- a/in/in_command.go
+++ b/in/in_command.go
@@ -1,0 +1,61 @@
+package in
+
+import (
+	"errors"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/starkandwayne/bosh2-errand-resource/bosh"
+	"github.com/starkandwayne/bosh2-errand-resource/concourse"
+)
+
+type InCommand struct {
+	director bosh.Director
+}
+
+type InResponse struct {
+	Version concourse.Version `json:"version"`
+}
+
+func NewInCommand(director bosh.Director) InCommand {
+	return InCommand{
+		director: director,
+	}
+}
+
+func (c InCommand) Run(inRequest concourse.InRequest, targetDir string) (InResponse, error) {
+	manifest, err := c.director.DownloadManifest()
+
+	if err != nil {
+		return InResponse{}, err
+	}
+	actualVersion := concourse.NewVersion(manifest, inRequest.Source.Target)
+
+	if actualVersion.Target != inRequest.Version.Target {
+		return InResponse{}, errors.New("Requested deployment director is different than configured source")
+	}
+
+	if actualVersion.ManifestSha1 != inRequest.Version.ManifestSha1 {
+		return InResponse{}, errors.New("Requested deployment version is not available")
+	}
+
+	releases := []string{}
+	for _, compiledRelease := range inRequest.Params.CompiledReleases {
+		releases = append(releases, compiledRelease.Name)
+	}
+	if err := c.director.ExportReleases(targetDir, releases); err != nil {
+		return InResponse{}, err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(targetDir, "manifest.yml"), manifest, 0644)
+	if err != nil {
+		return InResponse{}, err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(targetDir, "target"), []byte(actualVersion.Target), 0644)
+	if err != nil {
+		return InResponse{}, err
+	}
+
+	return InResponse{Version: actualVersion}, nil
+}

--- a/in/in_command.go
+++ b/in/in_command.go
@@ -39,14 +39,6 @@ func (c InCommand) Run(inRequest concourse.InRequest, targetDir string) (InRespo
 		return InResponse{}, errors.New("Requested deployment version is not available")
 	}
 
-	releases := []string{}
-	for _, compiledRelease := range inRequest.Params.CompiledReleases {
-		releases = append(releases, compiledRelease.Name)
-	}
-	if err := c.director.ExportReleases(targetDir, releases); err != nil {
-		return InResponse{}, err
-	}
-
 	err = ioutil.WriteFile(filepath.Join(targetDir, "manifest.yml"), manifest, 0644)
 	if err != nil {
 		return InResponse{}, err

--- a/in/in_command_test.go
+++ b/in/in_command_test.go
@@ -4,9 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"crypto/sha1"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -105,48 +103,6 @@ var _ = Describe("InCommand", func() {
 				_, err := inCommand.Run(inRequest, targetDir)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Requested deployment director is different than configured source"))
-			})
-		})
-
-		Context("when requesting compiled_releases", func() {
-			manifest := properYaml(`
-				releases:
-				- name: real-one
-				  version: "1"
-				- name: real-two
-				  version: "2.2"
-				stemcells:
-				- alias: default
-				  os: ubuntu-trusty
-				  version: "3309.8"
-			`)
-
-			BeforeEach(func() {
-				director.DownloadManifestReturns(manifest, nil)
-				inRequest.Version.ManifestSha1 = fmt.Sprintf("%x", sha1.Sum(manifest))
-				inRequest.Params.CompiledReleases = []concourse.CompiledRelease{
-					{Name: "real-one"},
-					{Name: "real-two"},
-				}
-			})
-
-			It("downloads each release with the version specified in the manifest", func() {
-				_, err := inCommand.Run(inRequest, targetDir)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(director.ExportReleasesCallCount()).To(Equal(1))
-
-				targetDir, releases := director.ExportReleasesArgsForCall(0)
-				Expect(targetDir).To(Equal(targetDir))
-				Expect(releases).To(Equal([]string{"real-one", "real-two"}))
-			})
-
-			Context("when exporting releases fails", func() {
-				It("errors", func() {
-					director.ExportReleasesReturns(errors.New("could not export"))
-					_, err := inCommand.Run(inRequest, targetDir)
-					Expect(err).To(MatchError(ContainSubstring("could not export")))
-				})
 			})
 		})
 	})

--- a/in/in_command_test.go
+++ b/in/in_command_test.go
@@ -1,0 +1,153 @@
+package in_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"crypto/sha1"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/starkandwayne/bosh2-errand-resource/bosh/boshfakes"
+	"github.com/starkandwayne/bosh2-errand-resource/concourse"
+	"github.com/starkandwayne/bosh2-errand-resource/in"
+)
+
+var _ = Describe("InCommand", func() {
+	var (
+		inCommand in.InCommand
+		director  *boshfakes.FakeDirector
+	)
+
+	BeforeEach(func() {
+		director = new(boshfakes.FakeDirector)
+		inCommand = in.NewInCommand(director)
+	})
+
+	Describe("Run", func() {
+		var inRequest concourse.InRequest
+		var targetDir string
+		sillyBytes := []byte{0xFE, 0xED, 0xDE, 0xAD, 0xBE, 0xEF}
+		sillyBytesSha1 := "33bf00cb7a45258748f833a47230124fcc8fa3a4"
+		wrongBytes := []byte{0x0F, 0xFE, 0xEF, 0xBE, 0xCF, 0xF0}
+
+		BeforeEach(func() {
+			inRequest = concourse.InRequest{
+				Source: concourse.Source{
+					Target: "director.example.com",
+				},
+				Version: concourse.Version{
+					ManifestSha1: sillyBytesSha1,
+					Target:       "director.example.com",
+				},
+			}
+
+			var err error
+			targetDir, err = ioutil.TempDir("", "")
+			Expect(err).ToNot(HaveOccurred())
+
+			director.DownloadManifestReturns(sillyBytes, nil)
+		})
+
+		It("writes the manifest and target to disk and returns the version as a response", func() {
+			inResponse, err := inCommand.Run(inRequest, targetDir)
+			Expect(err).ToNot(HaveOccurred())
+
+			manifestBytes, err := ioutil.ReadFile(filepath.Join(targetDir, "manifest.yml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(manifestBytes).To(Equal(sillyBytes))
+			Expect(director.DownloadManifestCallCount()).To(Equal(1))
+
+			targetBytes, err := ioutil.ReadFile(filepath.Join(targetDir, "target"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(targetBytes)).To(Equal("director.example.com"))
+
+			Expect(inResponse).To(Equal(in.InResponse{
+				Version: concourse.Version{
+					ManifestSha1: sillyBytesSha1,
+					Target:       "director.example.com",
+				},
+			}))
+		})
+
+		Context("when the manifest download fails", func() {
+			BeforeEach(func() {
+				director.DownloadManifestReturns(nil, errors.New("could not download manifest"))
+			})
+
+			It("returns an error", func() {
+				_, err := inCommand.Run(inRequest, targetDir)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("could not download manifest"))
+			})
+		})
+
+		Context("when downloaded manifest does not match the requested version", func() {
+			BeforeEach(func() {
+				director.DownloadManifestReturns(wrongBytes, nil)
+			})
+
+			It("returns an error", func() {
+				_, err := inCommand.Run(inRequest, targetDir)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Requested deployment version is not available"))
+			})
+		})
+
+		Context("when director target does not match the requested version", func() {
+			BeforeEach(func() {
+				inRequest.Source.Target = "weird.example.com"
+			})
+
+			It("returns an error", func() {
+				_, err := inCommand.Run(inRequest, targetDir)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Requested deployment director is different than configured source"))
+			})
+		})
+
+		Context("when requesting compiled_releases", func() {
+			manifest := properYaml(`
+				releases:
+				- name: real-one
+				  version: "1"
+				- name: real-two
+				  version: "2.2"
+				stemcells:
+				- alias: default
+				  os: ubuntu-trusty
+				  version: "3309.8"
+			`)
+
+			BeforeEach(func() {
+				director.DownloadManifestReturns(manifest, nil)
+				inRequest.Version.ManifestSha1 = fmt.Sprintf("%x", sha1.Sum(manifest))
+				inRequest.Params.CompiledReleases = []concourse.CompiledRelease{
+					{Name: "real-one"},
+					{Name: "real-two"},
+				}
+			})
+
+			It("downloads each release with the version specified in the manifest", func() {
+				_, err := inCommand.Run(inRequest, targetDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(director.ExportReleasesCallCount()).To(Equal(1))
+
+				targetDir, releases := director.ExportReleasesArgsForCall(0)
+				Expect(targetDir).To(Equal(targetDir))
+				Expect(releases).To(Equal([]string{"real-one", "real-two"}))
+			})
+
+			Context("when exporting releases fails", func() {
+				It("errors", func() {
+					director.ExportReleasesReturns(errors.New("could not export"))
+					_, err := inCommand.Run(inRequest, targetDir)
+					Expect(err).To(MatchError(ContainSubstring("could not export")))
+				})
+			})
+		})
+	})
+})

--- a/in/in_suite_test.go
+++ b/in/in_suite_test.go
@@ -1,0 +1,18 @@
+package in_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"strings"
+	"testing"
+)
+
+func TestOut(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "In Suite")
+}
+
+func properYaml(improperYaml string) []byte {
+	return []byte(strings.Replace(improperYaml, "\t", "  ", -1))
+}


### PR DESCRIPTION
Should fix:
```
hijack: Backend error: Exit status: 500, message: {"Type":"","Message":"runc exec: exit status 1: exec failed: container_linux.go:247: starting container process caused \"exec: \\\"/opt/resource/in\\\": stat /opt/resource/in: no such file or directory\"\n","Handle":""}
```