### PR TITLE
Update Dockerhub repo location to cfcommunity

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ resource_types:
 - name: bosh-errand
   type: docker-image
   source:
-    repository: cloudfoundry-community/bosh2-errand-resource
+    repository: cfcommunity/bosh2-errand-resource
 ```
 
 ## Source Configuration


### PR DESCRIPTION
The image is to be found at https://hub.docker.com/r/cfcommunity/bosh2-errand-resource/

Fixes #8 

The README will then match the CI pipeline https://github.com/cloudfoundry-community/bosh2-errand-resource/blob/master/ci/pipeline.yml#L16