### PR TITLE
Add option to skip source check

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ resource_types:
   the BOSH director will be dialed directly.
 * `jumpbox_ssh_key`: *Optional.* The private key of the jumpbox. If set, `jumpbox_url` must also be set.
 * `jumpbox_username`: *Optional.* The username for the jumpbox. If not set, will default to `jumpbox`.
+* `skip_check`: *Optional* Setting this will avoid failing checks when using this resource in dynamic configuration. If not set, will default to `false`.
 
 ### Example
 

--- a/concourse/source.go
+++ b/concourse/source.go
@@ -22,6 +22,7 @@ type Source struct {
 	JumpboxURL      string    `json:"jumpbox_url,omitempty" yaml:"jumpbox_url"`
 	JumpboxUsername string    `json:"jumpbox_username,omitempty" yaml:"jumpbox_username"`
 	VarsStore       VarsStore `json:"vars_store,omitempty" yaml:"vars_store"`
+	SkipCheck       bool      `json:"skip_check,omitempty" yaml:"skip_check"`
 }
 
 type sourceRequest struct {


### PR DESCRIPTION
Fixes check fails:
```
Issue with errand resource:
*resource script ‘/opt/resource/check []’ failed: exit status 1*

*stderr:*
*Expected non-empty Director URL*
```

git cherry-pick https://github.com/cloudfoundry/bosh-deployment-resource/commit/a2a4c6ee2775b7d960ef2578d82c6d0bd611f601